### PR TITLE
Fix CI by removing caching (fixes #7)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,21 +27,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
           override: true
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
       - name: Check
         run: cargo check
       - name: Rustfmt


### PR DESCRIPTION
We had the choice between committing Cargo.lock to version control, which is not recommended for a library like this according to the Cargo book, or removing these caching steps. After discussion we chose the latter option.